### PR TITLE
Updates CAC download path

### DIFF
--- a/modules/aws/cac/cac-startup.sh.tmpl
+++ b/modules/aws/cac/cac-startup.sh.tmpl
@@ -73,7 +73,7 @@ fi
 
 # download CAC installer
 curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
+tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz --no-same-owner -C /
 
 
 # Wait for service account to be added

--- a/modules/aws/cac/cac-startup.sh.tmpl
+++ b/modules/aws/cac/cac-startup.sh.tmpl
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 INSTALL_DIR="/root"
+CAC_BIN_PATH="/usr/sbin/cloud-access-connector"
 INSTALL_LOG="$INSTALL_DIR/cac-install.log"
 cd $INSTALL_DIR
 
@@ -44,7 +45,7 @@ get_credentials() {
     fi
 }
 
-if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
+if [[ -f "$CAC_BIN_PATH" ]]; then
     log "Connector already installed. Skipping startup script."
     exit 0
 fi
@@ -72,7 +73,7 @@ fi
 
 # download CAC installer
 curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
+tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
 
 
 # Wait for service account to be added
@@ -148,7 +149,7 @@ echo '### Installing Cloud Access Connector ###'
 export CAM_BASE_URI=${cam_url}
 
 if [ -z "${ssl_key}" ]; then
-    $INSTALL_DIR/cloud-access-connector install \
+    $CAC_BIN_PATH install \
         -t $CAC_TOKEN \
         --accept-policies \
         --insecure \
@@ -163,7 +164,7 @@ else
     aws s3 cp s3://${bucket_name}/${ssl_key} $INSTALL_DIR
     aws s3 cp s3://${bucket_name}/${ssl_cert} $INSTALL_DIR
 
-    $INSTALL_DIR/cloud-access-connector install \
+    $CAC_BIN_PATH install \
         -t $CAC_TOKEN \
         --accept-policies \
         --ssl-key $INSTALL_DIR/${ssl_key} \

--- a/modules/aws/cac/vars.tf
+++ b/modules/aws/cac/vars.tf
@@ -112,7 +112,7 @@ variable "admin_ssh_key_name" {
 
 variable "cac_installer_url" {
   description = "Location of the Cloud Access Connector installer"
-  default     = "https://teradici.bintray.com/cloud-access-connector/cloud-access-connector-0.1.1.tar.gz"
+  default     = "https://dl.teradici.com/yj39yHtgj68Uv2Qf/cloud-access-connector/raw/names/cloud-access-connector-linux-tgz/versions/latest/cloud-access-connector_latest_Linux.tar.gz"
 }
 
 variable "ssl_key" {

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -110,7 +110,7 @@ config_network() {
 download_cac() {
     log "--> Downloading CAC installer..."
     curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz --no-same-owner -C /
 }
 
 wait_for_dc() {

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -8,6 +8,7 @@
 LOG_FILE="/var/log/teradici/provisioning.log"
 
 INSTALL_DIR="/root"
+CAC_BIN_PATH="/usr/sbin/cloud-access-connector"
 CAC_INSTALL_LOG="/var/log/teradici/cac-install.log"
 cd $INSTALL_DIR
 
@@ -82,7 +83,7 @@ check_required_vars() {
 }
 
 check_connector_installed() {
-    if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
+    if [[ -f "$CAC_BIN_PATH" ]]; then
         log "--> Connector already installed. Skipping provisioning script..."
         exit 0
     fi
@@ -109,7 +110,7 @@ config_network() {
 download_cac() {
     log "--> Downloading CAC installer..."
     curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
 }
 
 wait_for_dc() {
@@ -185,7 +186,7 @@ install_cac() {
     log "--> Installing Cloud Access Connector..."
     export CAM_BASE_URI=${cam_url}
 
-    log "--> Running command: $INSTALL_DIR/cloud-access-connector install"
+    log "--> Running command: $CAC_BIN_PATH install"
     log "--> CAC install options:"
     log "-t <cac_token> --accept-policies"
     log "--sa-user <ad_service_account_username> --sa-password <ad_service_account_password>"
@@ -195,7 +196,7 @@ install_cac() {
     if [ -z "${ssl_key}" ]; then
         log "--insecure"
 
-        $INSTALL_DIR/cloud-access-connector install \
+        $CAC_BIN_PATH install \
             -t $CAC_TOKEN \
             --accept-policies \
             --insecure \
@@ -212,7 +213,7 @@ install_cac() {
 
         log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
 
-        $INSTALL_DIR/cloud-access-connector install \
+        $CAC_BIN_PATH install \
             -t $CAC_TOKEN \
             --accept-policies \
             --ssl-key $INSTALL_DIR/${ssl_key} \

--- a/modules/gcp/cac-igm/vars.tf
+++ b/modules/gcp/cac-igm/vars.tf
@@ -107,7 +107,7 @@ variable "cac_admin_ssh_pub_key_file" {
 
 variable "cac_installer_url" {
   description = "Location of the Cloud Access Connector installer"
-  default     = "https://teradici.bintray.com/cloud-access-connector/cloud-access-connector-0.1.1.tar.gz"
+  default     = "https://dl.teradici.com/yj39yHtgj68Uv2Qf/cloud-access-connector/raw/names/cloud-access-connector-linux-tgz/versions/latest/cloud-access-connector_latest_Linux.tar.gz"
 }
 
 variable "kms_cryptokey_id" {

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -110,7 +110,7 @@ config_network() {
 download_cac() {
     log "--> Downloading CAC installer..."
     curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz --no-same-owner -C /
 }
 
 wait_for_dc() {

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -8,6 +8,7 @@
 LOG_FILE="/var/log/teradici/provisioning.log"
 
 INSTALL_DIR="/root"
+CAC_BIN_PATH="/usr/sbin/cloud-access-connector"
 CAC_INSTALL_LOG="/var/log/teradici/cac-install.log"
 cd $INSTALL_DIR
 
@@ -82,7 +83,7 @@ check_required_vars() {
 }
 
 check_connector_installed() {
-    if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
+    if [[ -f "$CAC_BIN_PATH" ]]; then
         log "--> Connector already installed. Skipping provisioning script..."
         exit 0
     fi
@@ -109,7 +110,7 @@ config_network() {
 download_cac() {
     log "--> Downloading CAC installer..."
     curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz -C /
 }
 
 wait_for_dc() {
@@ -185,7 +186,7 @@ install_cac() {
     log "--> Installing Cloud Access Connector..."
     export CAM_BASE_URI=${cam_url}
 
-    log "--> Running command: $INSTALL_DIR/cloud-access-connector install"
+    log "--> Running command: $CAC_BIN_PATH install"
     log "--> CAC install options:"
     log "-t <cac_token> --accept-policies"
     log "--sa-user <ad_service_account_username> --sa-password <ad_service_account_password>"
@@ -195,7 +196,7 @@ install_cac() {
     if [ -z "${ssl_key}" ]; then
         log "--insecure"
 
-        $INSTALL_DIR/cloud-access-connector install \
+        $CAC_BIN_PATH install \
             -t $CAC_TOKEN \
             --accept-policies \
             --insecure \
@@ -212,7 +213,7 @@ install_cac() {
 
         log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
 
-        $INSTALL_DIR/cloud-access-connector install \
+        $CAC_BIN_PATH install \
             -t $CAC_TOKEN \
             --accept-policies \
             --ssl-key $INSTALL_DIR/${ssl_key} \

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -112,7 +112,7 @@ variable "cac_admin_ssh_pub_key_file" {
 
 variable "cac_installer_url" {
   description = "Location of the Cloud Access Connector installer"
-  default     = "https://teradici.bintray.com/cloud-access-connector/cloud-access-connector-0.1.1.tar.gz"
+  default     = "https://dl.teradici.com/yj39yHtgj68Uv2Qf/cloud-access-connector/raw/names/cloud-access-connector-linux-tgz/versions/latest/cloud-access-connector_latest_Linux.tar.gz"
 }
 
 variable "ssl_key" {


### PR DESCRIPTION
Teradici is migrating away from bintray for CAC downloads. This patch
updates the CAC modules with the new download path and also where
cloud-access-connector is installed by default (/usr/sbin/)

Signed-off-by: Sherman Yin <syin@teradici.com>